### PR TITLE
Update Github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# Set update schedule for GitHub Actions
+# Copied from https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.11
+          python-version: 3.12
           cache: 'poetry'
 
       - name: Cache Playwright browsers

--- a/tests/test_main_page.py
+++ b/tests/test_main_page.py
@@ -4,9 +4,7 @@ from pages.page_objects.main_page import MainPage
 
 
 def test_main_banner(main_page: MainPage) -> None:
-
     expected_banner = 'Experience and dedication you can trust'
-
 
     main_page.load_and_accept_cookies()
 


### PR DESCRIPTION
After upgrading Python version in pyproject.toml to 3.12, Github actions got broken so:

- Update Python version
- Add dependabot to check for outdated actions